### PR TITLE
update python-control to v0.8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
+*~
 
 build_artefacts

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,4 +42,3 @@ extra:
   recipe-maintainers:
     - moorepants
     - murrayrm
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "control" %}
-{% set version = "0.7.0" %}
-{% set sha256 = "18ce26206e40f4ba62b2a0bf86943598a6ec3f957e15bd46d17b9e1e314f19d6" %}
+{% set version = "0.8.0" %}
+{% set sha256 = "4e3dbdce88e2bc2bd06e4a3cbc3421369f2c0f38e496445858319aba950430be" %}
 
 package:
   name: {{ name|lower }}
@@ -41,3 +41,5 @@ about:
 extra:
   recipe-maintainers:
     - moorepants
+    - murrayrm
+


### PR DESCRIPTION
Updated version of python-control has been posted to PyPI and is ready for release via conda-forge.  Main updates are to the default version and the SHA256 hash.  Also added a line to `.gitignore` to ignore backup files generated by emacs.
